### PR TITLE
Offer exporting jar of jdom.contrib

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+bin/
+build/

--- a/contrib/build.gradle
+++ b/contrib/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply plugin: 'maven'
+
+group = 'org.jdom'
+version = '2.0.0'
+
+sourceCompatibility = '1.6'
+targetCompatibility = '1.6'
+
+sourceSets {
+	main {
+		java {
+			srcDir 'src/java'
+		}
+		resources {
+			srcDir 'src/resource'
+		}
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+configurations.compile.transitive = true
+dependencies {
+	compile 'org.jdom:jdom2:2.0.+'
+	compile 'xalan:xalan:2.7.1'
+	compile 'xalan:serializer:2.7.1'
+	compile 'isorelax:isorelax:20030108'
+	
+	// JDOM is required, because main and test are not separated
+	compile 'junit:junit:4.11'
+}
+


### PR DESCRIPTION
I wanted to use `org.jdom2.contrib.dom.DOM.wrap` as mentioned in an answer to the question [Is there any org.w3c.dom wrapper for JDom?](http://stackoverflow.com/a/10210571/873282) on stackoverflow. For that, I required a jar file. I added a (gradle)[http://www.gradle.org/] build file to enable creating a jar (`gradle jar`) and uploading it to the local maven repository (`gradle install`). I did not add the [Gradle Wrapper](http://www.gradle.org/docs/current/userguide/gradle_wrapper.html), so gradle binaries are required.
