### PR TITLE
merging CDATAs can producing an ending tag ]]> in the resulting CDATA leading to an exception

### DIFF
--- a/core/src/java/org/jdom/input/SAXHandler.java
+++ b/core/src/java/org/jdom/input/SAXHandler.java
@@ -731,7 +731,7 @@ public class SAXHandler extends DefaultHandler implements LexicalHandler,
         if (suppress || (length == 0))
             return;
 
-        if (previousCDATA != inCDATA || (ch[start] == '>' || (ch[start] == ']' && ch[start] == '>') )) {
+        if (previousCDATA != inCDATA || (ch[start] == '>' || (ch[start] == ']' && length > 1 && ch[start+1] == '>') )) {
             flushCharacters();
         }
 


### PR DESCRIPTION
Imagine you have the following XML input:

``` xml
     <message priority="info"><![CDATA[  expected:<[[D/0]]]]><![CDATA[> but was:<[null]>]]></message>
```

this would be a legal XML representing the following string:

```
expected:<[[D/0]]> but was: <[null]>
```

now when SAXHandler.characters() gets called, it would try to merge subsequent CDATAs, and call setText() which would fail with:

```
Caused by: org.jdom.IllegalDataException: The data "  expected:<[[D/0]]> but was:<[null]>" is not legal for a JDOM CDATA section: CDATA cannot internally contain a CDATA ending delimiter (]]>).
at org.jdom.CDATA.setText(CDATA.java:121)
at org.jdom.CDATA.<init>(CDATA.java:95)
at org.jdom.DefaultJDOMFactory.cdata(DefaultJDOMFactory.java:97)
at org.jdom.input.SAXHandler.flushCharacters(SAXHandler.java:652)
at org.jdom.input.SAXHandler.flushCharacters(SAXHandler.java:623)
at org.jdom.input.SAXHandler.endElement(SAXHandler.java:678)
at org.apache.xerces.parsers.AbstractSAXParser.endElement(Unknown Source)
```

It's not a nice fix, but its an easy workaround.
