### PR TITLE
Fix for NPE on null attribute name

### DIFF
--- a/core/src/java/org/jdom2/AttributeList.java
+++ b/core/src/java/org/jdom2/AttributeList.java
@@ -427,8 +427,8 @@ final class AttributeList extends AbstractList<Attribute>
 			final String uri = namespace.getURI();
 			for (int i = 0; i < size; i++) {
 				final Attribute att = attributeData[i];
-				if (uri.equals(att.getNamespaceURI()) &&
-						name.equals(att.getName())) {
+				if (att.getNamespaceURI().equals(uri) &&
+						att.getName().equals(name)) {
 					return i;
 				}
 			}


### PR DESCRIPTION
In JDOM 1.x, AttributeList did not throw a null pointer exception on a null attribute name. JDOM 2.x currently does. This PR is a quick fix for that issue by changing the comparison order to be more defensive.